### PR TITLE
Don't hardcode but use GPG key URL from attributes for debian

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,7 +56,7 @@ when 'debian'
     uri node['stackdriver']['repo_url']
     distribution node['stackdriver']['repo_dist']
     components ['main']
-    key 'https://www.stackdriver.com/RPM-GPG-KEY-stackdriver'
+    key node['stackdriver']['gpg_key']
     only_if { node['stackdriver']['enable'] }
   end
 


### PR DESCRIPTION
This PR fixes errors like the following that arise out of wrong GPG key path for stackdriver. The path was [updated in the attributes here](https://github.com/tablexi/chef-stackdriver/pull/10/files#diff-25e5d4a4446ae12a0d6f1162b6160375R23) but not used for debian packages before.

````
[2016-01-18T11:08:13+00:00] INFO: Processing apt_repository[stackdriver] action add (stackdriver::default line 53)
[2016-01-18T11:08:13+00:00] INFO: Processing remote_file[/var/lib/aws/opsworks/cache.stage2/RPM-GPG-KEY-stackdriver] action create (/var/lib/aws/opsworks/cache.stage2/cookbooks/apt/providers/repository.rb line 90)
[2016-01-18T11:08:13+00:00] INFO: remote_file[/var/lib/aws/opsworks/cache.stage2/RPM-GPG-KEY-stackdriver] created file /var/lib/aws/opsworks/cache.stage2/RPM-GPG-KEY-stackdriver
[2016-01-18T11:08:13+00:00] INFO: HTTP Request Returned 400 Bad Request:

================================================================================
Error executing action `create` on resource 'remote_file[/var/lib/aws/opsworks/cache.stage2/RPM-GPG-KEY-stackdriver]'
================================================================================


Net::HTTPServerException
------------------------
400 "Bad Request"


Resource Declaration:
---------------------
# In /var/lib/aws/opsworks/cache.stage2/cookbooks/apt/providers/repository.rb

90:     remote_file cached_keyfile do
91:       source new_resource.key
92:       mode 00644
93:       sensitive new_resource.sensitive if respond_to?(:sensitive)
94:       action :create
95:     end
96:   else



Compiled Resource:
------------------
# Declared in /var/lib/aws/opsworks/cache.stage2/cookbooks/apt/providers/repository.rb:90:in `install_key_from_uri'

remote_file("/var/lib/aws/opsworks/cache.stage2/RPM-GPG-KEY-stackdriver") do
provider Chef::Provider::RemoteFile
action [:create]
retries 0
retry_delay 2
path "/var/lib/aws/opsworks/cache.stage2/RPM-GPG-KEY-stackdriver"
backup 5
atomic_update true
source ["https://www.stackdriver.com/RPM-GPG-KEY-stackdriver"]
use_etag true
use_last_modified true
cookbook_name "stackdriver"
mode 420
end



[2016-01-18T11:08:13+00:00] INFO: Running queued delayed notifications before re-raising exception
````